### PR TITLE
fix: Fix var price jioJoinerOrder crash

### DIFF
--- a/src/screens/JioJoinerOrder.js
+++ b/src/screens/JioJoinerOrder.js
@@ -53,7 +53,7 @@ class JioJoinerOrder extends Component {
                         placeholder="How much does everything cost?"
                         label="PRICE"
                         value={this.state.price}
-                        onChangeText={order => this.setState({ price })}
+                        onChangeText={price => this.setState({ price })}
                         // TODO: typing into this element results in crashing. can we fix this?
                         // TODO: this should be a number input? can we find some other input for this? whatever looks nice
                     /> 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Basically made sure that all variables are referenced, and made available for use, in JioJoinerOrder

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolve #18 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested out inputting data in price box (see screenshot) - No errors

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/19257264/60318364-5074db80-99a5-11e9-9dc2-62a98d062cf8.png)
Typing in price works!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.