### PR TITLE
feat: Link createjio to addorder

### DIFF
--- a/src/components/MainPage/JioList.js
+++ b/src/components/MainPage/JioList.js
@@ -32,12 +32,6 @@ class JioList extends Component {
                 console.log(this.state.allOrders);
                 console.log(this.state.orderOne);
             });
-            // .then((success) => {
-            //     console.log('Success Message: ', success) // success callback
-            // })
-            // .catch((error) => {
-            //     console.log('Error Message: ', error) // error callback
-            // });
     }
 
     renderJio() {

--- a/src/screens/CoordinatorCreateJio.js
+++ b/src/screens/CoordinatorCreateJio.js
@@ -14,12 +14,13 @@ class CoordinatorCreateJio extends Component {
         promoCode: '',
         jioOpenTime: '',
         jioCloseTime: '',
-        jioArrivalTime: ''
+        jioArrivalTime: '',
+        order: {},
     };
 
     handleSubmit() {
         // a method called after button is pressed
-        let postData = {
+        const postData = {
             orderId: 9999, // TODO: generate this somehow in future
             store: this.state.store, 
             coordinatorName: '<INSERT NAME>', // TODO: get info from user account
@@ -36,14 +37,16 @@ class CoordinatorCreateJio extends Component {
             foodOrders: [],
         }
 
-        let dbLocation = '/allOrders/';
+        const dbLocation = '/allOrders/';
+
+        this.setState({ order: postData });
 
         db
             .ref(dbLocation)
             .push(postData)
             .then((success) => {
                 console.log('Success Message: ', success) // success callback
-                Actions.mainPage(); // TODO: Add some way to confirm that jio has been created/switch to dashboard when it's ready
+                Actions.jioJoinerOrder({ order: this.state.order });
             })
             .catch((error) => {
                 console.log('Error Message: ', error) // error callback
@@ -57,6 +60,7 @@ class CoordinatorCreateJio extends Component {
 
         return(
             <View style={containerStyle}>
+                <Text>{this.state.order.phoneNumber}</Text>
                 <Text style={storeStyle}>NEW JIO</Text>
                 <Input 
                     placeholder="Where do I want to eat from?"

--- a/src/screens/JioJoinerOrder.js
+++ b/src/screens/JioJoinerOrder.js
@@ -20,7 +20,7 @@ class JioJoinerOrder extends Component {
             specialRequests: this.state.specialRequests,
         }
 
-        let orderId = this.props.order.orderId - 1; // for accessing the array
+        let orderId = this.props.order.orderId - 1; // for accessing the array, has to be changed in the future
         let dbLocation = '/allOrders/' + orderId + '/foodOrders/';
 
         db


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Link CreateJio to navigate to AddOrder after

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Logically, user should be able to Join the Jio automatically after creating it. This navigates to the right page, and passes the relevant information needed in AddOrder.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Checked on firebase to see, but presently the order isn't added to the right place in firebase, because we need to find a new way to access the specific order number. It's just added to some random part of firebase. (see screenshot)

## Screenshots
![image](https://user-images.githubusercontent.com/19257264/60319406-e3fbdb80-99a8-11e9-8efb-3b74a5b361c9.png)
9998 references the orderID that the foodOrders was meant to be added into
The KFC offer is the created Jio. We need to one day link the two together somehow, and figure out what's the best way to access the Jio and edit info from there.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.