### PR TITLE
feat: Able to Join existing Jios (Jio Joining Works!)

### DIFF
--- a/src/components/MainPage/JioDetails.js
+++ b/src/components/MainPage/JioDetails.js
@@ -28,7 +28,10 @@ class JioDetails extends Component {
         if(this.props.fromDashboard) {
             Actions.coordinator({ order: this.props.order});
         } else {
-            Actions.jioInformation({ order: this.props.order});
+            Actions.jioInformation({ 
+                order: this.props.order,
+                foodOrderId: this.props.foodOrderId
+            });
         }
     }
 

--- a/src/components/MainPage/JioDetails.js
+++ b/src/components/MainPage/JioDetails.js
@@ -21,9 +21,6 @@ import { //TODO: Change status into states? Not sure how the constants help and 
 } from '../../data/jio-states'
 
 class JioDetails extends Component {
-    // state = {jioStatus: {this.props.order.jioStatus}};
-    // console.log(this.state.jioStatus);
-
     renderNextPage() {
         if(this.props.fromDashboard) {
             Actions.coordinator({ order: this.props.order});
@@ -60,9 +57,7 @@ class JioDetails extends Component {
                     : this.props.order.jioStatus === 'jioPaid' 
                         ? Paid
                         : this.props.order.jioStatus === 'jioArrived'
-                            ? Arrive : Complete; 
-
-        // console.log(this.props.order);        
+                            ? Arrive : Complete;     
     
         return (
             <TouchableOpacity onPress={() => this.renderNextPage()}>

--- a/src/components/MainPage/JioList.js
+++ b/src/components/MainPage/JioList.js
@@ -22,8 +22,6 @@ class JioList extends Component {
             .on('value', snapshot => {
                 let allOrders = snapshot.val();
                 this.setState({ allOrders });
-                console.log(Object.values(this.state.allOrders))
-                console.log(Object.keys(this.state.allOrders))
             });
     }
 
@@ -31,7 +29,6 @@ class JioList extends Component {
     //     // order.item is because renderItem in FlatList, requires index, item and separator
     //     // whereas all the data that we currently want is centred in item. Can make use of the rest
     //     // if time permits
-    //     console.log(index)
     //     return (
     //         <JioDetails order={item} foodOrderId={index}/>
     //     );

--- a/src/components/MainPage/JioList.js
+++ b/src/components/MainPage/JioList.js
@@ -22,23 +22,32 @@ class JioList extends Component {
             .on('value', snapshot => {
                 let allOrders = snapshot.val();
                 this.setState({ allOrders });
+                console.log(Object.values(this.state.allOrders))
+                console.log(Object.keys(this.state.allOrders))
             });
     }
 
-    renderJio(order) {
-        // order.item is because renderItem in FlatList, requires index, item and separator
-        // whereas all the data that we currently want is centred in item. Can make use of the rest
-        // if time permits
-        return (
-            <JioDetails order={order.item} />
-        );
-    }
+    // renderJio(order) {
+    //     // order.item is because renderItem in FlatList, requires index, item and separator
+    //     // whereas all the data that we currently want is centred in item. Can make use of the rest
+    //     // if time permits
+    //     console.log(index)
+    //     return (
+    //         <JioDetails order={item} foodOrderId={index}/>
+    //     );
+    // }
 
     render() {
         return(
             <FlatList 
-                data={Object.values(this.state.allOrders)}
-                renderItem={this.renderJio}
+                data={Object.entries(this.state.allOrders)}
+                // renderItem={this.renderJio({item, index})}
+                renderItem={({item, index}) => (
+                    <JioDetails
+                        order={item[1]}
+                        foodOrderId={item[0]}
+                    />
+                )}
                 keyExtractor={order => order.store}
             />
         );

--- a/src/screens/JioInformation.js
+++ b/src/screens/JioInformation.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import { Actions } from 'react-native-router-flux';
 import { Button, NavBar } from '../components/common';
 import FullJioDetails from '../components/JioInformation/FullJioDetails';
@@ -10,7 +10,10 @@ class JioInformation extends Component {
             <View style={styles.containerStyle}>
                 <FullJioDetails order={this.props.order}/>
                 <View>
-                    <Button onPress={() => { Actions.jioJoinerOrder({ order : this.props.order }) }}>
+                    <Button onPress={() => { Actions.jioJoinerOrder({ 
+                        order : this.props.order, 
+                        foodOrderId: this.props.foodOrderId}) 
+                        }}>
                         + JOIN JIO
                     </Button>
                     <NavBar />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5932,6 +5932,19 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
+react-native-iphone-x-helper@^1.0.3:
+  version "1.2.1"
+  resolved "https://npm.k8s.vidds.ee/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
+  integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
+
+react-native-keyboard-aware-scroll-view@^0.8.0:
+  version "0.8.0"
+  resolved "https://npm.k8s.vidds.ee/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.8.0.tgz#00bcaa38c91323913bb7a733059ad2bc4875f88c"
+  integrity sha512-gPfhgHQI/z7Cc5aeNOEmK0b250QkAeU6V+4oH8EC7mmFneEKn6MAIDjpoiwqt6bV+lFJPABXfx9MtrRmtCeJ/Q==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-iphone-x-helper "^1.0.3"
+
 react-native-router-flux@^4.0.6:
   version "4.0.6"
   resolved "https://npm.k8s.vidds.ee/react-native-router-flux/-/react-native-router-flux-4.0.6.tgz#e4723f5ce89cb5822e0c9bb6d0a8d4de6179eb58"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously, could not add JioOrder to previous jios. Now, this is possible!

## Description
<!--- Describe your changes in detail -->
Changed FlatList to not only take in the `values` but also the `entries` such that the alphanumeric gibberish/firebase-generated object IDs can be passed down to `JioJoinerOrder`.

However, the `Coordinator` navigation page for each of the orders seems to be down. Will fix it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jio Joining is now possible, not only for the coordinator!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Firebase is now updated for previous orders if we add orders via the application!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.