### PR TITLE
fix: Remove secureTextEntry from all inputs

### DIFF
--- a/src/components/common/Input.js
+++ b/src/components/common/Input.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, View, TextInput } from 'react-native';
 
-const Input = ({ label, value, onChangeText, placeholder }) => {
+const Input = ({ label, value, onChangeText, placeholder, secureTextEntry }) => {
     const { inputStyle, labelStyle, containerStyle, inputContainerStyle } = styles;
 
     return (
@@ -13,7 +13,7 @@ const Input = ({ label, value, onChangeText, placeholder }) => {
                 style={inputStyle}
                 value={value}
                 onChangeText={onChangeText}
-                secureTextEntry
+                secureTextEntry={secureTextEntry}
                 />
             </View>
         </View>

--- a/src/screens/Router.js
+++ b/src/screens/Router.js
@@ -48,7 +48,6 @@ const RouterComponent = () => {
                     key="dashboard"
                     component={Dashboard}
                     title="Your Jios"
-                    initial
                 />
                 <Scene
                     key="coordinator"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Accidentally gave all the `Input` components `secureTextEntry` prop in PR #38. Fixed in this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.