### PR TITLE
fix: Ongoing Jio filtering fixed

### DIFF
--- a/src/components/Dashboard/OngoingDetails.js
+++ b/src/components/Dashboard/OngoingDetails.js
@@ -60,12 +60,14 @@ class OngoingDetails extends Component {
                     let filteredOrders = []
                     allOrdersArr.forEach((order) => {
                         let orderIncludesUser = false
-                        let foodOrdersArr = Object.values(order.foodOrders)
-                        console.log(foodOrdersArr)
-                        for(let i = 0; i < foodOrdersArr.length; i++) {
-                            if(foodOrdersArr[i].joinerName === this.state.userData.displayName) {
-                                orderIncludesUser = true
-                                console.log('FOOD ORDER ACCEPTED')
+                        if(order.coordinatorName !== this.state.userData.displayName) {
+                            let foodOrdersArr = Object.values(order.foodOrders)
+                            console.log(foodOrdersArr)
+                            for(let i = 0; i < foodOrdersArr.length; i++) {
+                                if(foodOrdersArr[i].joinerName === this.state.userData.displayName) {
+                                    orderIncludesUser = true
+                                    console.log('FOOD ORDER ACCEPTED')
+                                }
                             }
                         }
                         if(orderIncludesUser) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Filtering previously showed all coordinator jios outside of initiated jios, because they have food orders inside too. However, this shouldn't happen. It should show jios whereby they are not coordinators but are food orderers. This has been fixed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/19257264/61576658-3b581c00-ab0f-11e9-8582-2fa91b66b1a8.png)
New Jio Filter (for user Cheryl)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.