### PR TITLE
fix: jioOrderId of all dashboard jios now have the correct firebase id

### DIFF
--- a/src/components/Dashboard/InitiatedDetails.js
+++ b/src/components/Dashboard/InitiatedDetails.js
@@ -59,22 +59,15 @@ class InitiatedDetails extends Component {
             .endAt('3jioArrived')
             .on('value', snapshot => {
                 let allOrders = snapshot.val();
-                console.log('INITIATED DETAILS ORDERS: ')
                 if ( allOrders === null ) {
                     return null;
                 } else {
                     let allOrdersArr = Object.entries(allOrders)
-                    console.log('NEW ARRAY ORDERS: ')
-                    console.log(allOrdersArr)
                     let filteredOrders = []
                     allOrdersArr.forEach((order) => {
                         if(order[1].coordinatorName === this.state.userData.displayName) {
                             filteredOrders.push(order)
-                            // console.log('ADDING TO FILTERED')
-                        } else {
-                            // console.log('IGNORING ORDER')
-                        }
-                    })
+                    }})
                     this.setState({ allOrders: filteredOrders });
                 } 
             });

--- a/src/components/Dashboard/OngoingDetails.js
+++ b/src/components/Dashboard/OngoingDetails.js
@@ -56,12 +56,14 @@ class OngoingDetails extends Component {
                 if ( allOrders === null ) {
                     return null;
                 } else {
-                    let allOrdersArr = Object.values(allOrders)
+                    let allOrdersArr = Object.entries(allOrders)
+                    console.log('ALL ORDERS ARRAY: ')
+                    console.log(allOrdersArr)
                     let filteredOrders = []
                     allOrdersArr.forEach((order) => {
                         let orderIncludesUser = false
-                        if(order.coordinatorName !== this.state.userData.displayName) {
-                            let foodOrdersArr = Object.values(order.foodOrders)
+                        if(order[1].coordinatorName !== this.state.userData.displayName) {
+                            let foodOrdersArr = Object.values(order[1].foodOrders)
                             console.log(foodOrdersArr)
                             for(let i = 0; i < foodOrdersArr.length; i++) {
                                 if(foodOrdersArr[i].joinerName === this.state.userData.displayName) {
@@ -102,7 +104,7 @@ class OngoingDetails extends Component {
     render() {
         return(
             <FlatList 
-                data={Object.entries(this.state.allOrders)}
+                data={this.state.allOrders}
                 renderItem={this.renderJio}
                 keyExtractor={this.keyExtractor}
             />

--- a/src/components/Dashboard/OngoingDetails.js
+++ b/src/components/Dashboard/OngoingDetails.js
@@ -52,31 +52,27 @@ class OngoingDetails extends Component {
             .endAt('3jioArrived')
             .on('value', snapshot => {
                 let allOrders = snapshot.val();
-                console.log(allOrders)
                 if ( allOrders === null ) {
                     return null;
                 } else {
                     let allOrdersArr = Object.entries(allOrders)
-                    console.log('ALL ORDERS ARRAY: ')
-                    console.log(allOrdersArr)
                     let filteredOrders = []
                     allOrdersArr.forEach((order) => {
                         let orderIncludesUser = false
                         if(order[1].coordinatorName !== this.state.userData.displayName) {
                             let foodOrdersArr = Object.values(order[1].foodOrders)
-                            console.log(foodOrdersArr)
                             for(let i = 0; i < foodOrdersArr.length; i++) {
                                 if(foodOrdersArr[i].joinerName === this.state.userData.displayName) {
                                     orderIncludesUser = true
-                                    console.log('FOOD ORDER ACCEPTED')
+                                    // console.log('FOOD ORDER ACCEPTED')
                                 }
                             }
                         }
                         if(orderIncludesUser) {
                             filteredOrders.push(order)
-                            console.log('ADDING ORDER TO FILTERED')
+                            // console.log('ADDING ORDER TO FILTERED')
                         } else {
-                            console.log('IGNORING ORDER')
+                            // console.log('IGNORING ORDER')
                         }
                     })
                     this.setState({ allOrders: filteredOrders });

--- a/src/components/Dashboard/PreviousDetails.js
+++ b/src/components/Dashboard/PreviousDetails.js
@@ -60,11 +60,11 @@ class PreviousDetails extends Component {
                 if ( allOrders === null ) {
                     return null;
                 } else {
-                    let allOrdersArr = Object.values(allOrders)
+                    let allOrdersArr = Object.entries(allOrders)
                     let filteredOrders = []
                     allOrdersArr.forEach((order) => {
                         let orderIncludesUser = false
-                        let foodOrdersArr = Object.values(order.foodOrders)
+                        let foodOrdersArr = Object.values(order[1].foodOrders)
                         for(let i = 0; i < foodOrdersArr.length; i++) {
                             if(foodOrdersArr[i].joinerName === this.state.userData.displayName) {
                                 orderIncludesUser = true
@@ -100,7 +100,7 @@ class PreviousDetails extends Component {
     render() {
         return(
             <FlatList 
-                data={Object.entries(this.state.allOrders)}
+                data={this.state.allOrders}
                 style={styles.containerStyle}
                 renderItem={this.renderJio}
                 keyExtractor={this.keyExtractor}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously, the `jioOrderId` was the array index of the dashboard jios. Now, they are the correct firebase ID, connecting to the right firebase calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For future database edits from these detail pages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Previewed the received `jioOrderId` prop in `jioDetails`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.