### PR TITLE
fix: Auto update Coordinator jioStatus + Calc accounts for minOrder

### DIFF
--- a/src/components/Coordinator/CoordinatorFullJio.js
+++ b/src/components/Coordinator/CoordinatorFullJio.js
@@ -10,7 +10,7 @@ import { Actions } from 'react-native-router-flux';
 // Consider using ComponentWillUpdate()
 class CoordinatorFullJio extends Component {
     renderEdit() {
-        if (this.props.order.jioStatus === '1jioOpen') {
+        if (this.props.jioStatus === '1jioOpen') {
             return(
                 <TouchableOpacity onPress={() => Actions.coordinatorEditJio({ 
                     order: this.props.order,
@@ -34,7 +34,7 @@ class CoordinatorFullJio extends Component {
 
         return(
             <View>
-                <Text style={styles.textStyle}>Status : {jioStatusText(this.props.order.jioStatus)}</Text>
+                <Text style={styles.textStyle}>Status : {jioStatusText(this.props.jioStatus)}</Text>
                 <Text style={styles.textStyle}>Location : {jioLocation}</Text>
                 <TimeOrange>
                     <View style={{flexDirection: 'row', alignItems: 'flex-end', justifyContent: 'space-between', flex: 3}}>

--- a/src/components/Coordinator/OrderDetails.js
+++ b/src/components/Coordinator/OrderDetails.js
@@ -54,10 +54,20 @@ class OrderDetails extends Component {
     }
 
     calcPrice() {
+        // TODO: account for minimum order in future. for now it's assumed that it hits minimum order
         const count = parseFloat(this.props.jioJoinerNum);
         const eachDelivery = parseFloat(this.props.order.deliveryCost) / count;
         const disc = (100 - parseFloat(this.props.order.discount)) / 100;
-        const paidPrice = parseFloat(this.props.orderDetails.price) * disc + eachDelivery;
+        const foodOrders = Object.values(this.props.order.foodOrders);
+        let totalPrice = 0.00;
+        for(let i = 0; i < foodOrders.length; i++) {
+            totalPrice += parseFloat(foodOrders[i].price)
+        }
+        const isDiscountApplied = totalPrice >= parseFloat(this.props.order.minOrder)
+        const paidPrice = isDiscountApplied
+            ? parseFloat(this.props.orderDetails.price) * disc + eachDelivery
+            : parseFloat(this.props.orderDetails.price) + eachDelivery
+        // const paidPrice = parseFloat(this.props.orderDetails.price) * disc + eachDelivery;
         const priceString = '$' + paidPrice.toFixed(2);
         return priceString;
     }

--- a/src/screens/Coordinator.js
+++ b/src/screens/Coordinator.js
@@ -56,7 +56,8 @@ class Coordinator extends Component {
             containerStyle,
             storeStyle,
             editStyle,
-            headerStyle
+            headerStyle,
+            textStyle
         } = styles;
 
         return(
@@ -66,6 +67,7 @@ class Coordinator extends Component {
                     <CoordinatorFullJio 
                         order={this.props.order}
                         jioOrderId={this.props.jioOrderId}
+                        jioStatus={this.state.jioStatus}
                     />
                 </ScrollView>
                 <View>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the bug mentioned in #37 and the calculator now accounts for the minimum order. Now the jioStatus updates automatically in the coordinator page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in simulator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.